### PR TITLE
Add MCP Servers section with evc-team-relay-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,3 +1070,17 @@ No description available.
 *Updated: 2025-11-25*
 
 ---
+
+## MCP Servers for Obsidian
+
+*External MCP (Model Context Protocol) servers that provide AI agent access to Obsidian vaults. Unlike plugins, these run as separate processes and connect via the MCP protocol.*
+
+### EVC Team Relay MCP
+
+[![GitHub stars](https://img.shields.io/github/stars/entire-vc/evc-team-relay-mcp?style=flat-square)](https://github.com/entire-vc/evc-team-relay-mcp)
+[![GitHub](https://img.shields.io/badge/GitHub-entire--vc%2Fevc--team--relay--mcp-181717?logo=github)](https://github.com/entire-vc/evc-team-relay-mcp)
+[![PyPI](https://img.shields.io/badge/PyPI-evc--team--relay--mcp-blue?logo=pypi)](https://pypi.org/project/evc-team-relay-mcp/)
+
+Give AI agents read/write access to your Obsidian vault through Team Relay collaborative server. Python, MIT. 5 MCP tools: list_notes, read_note, write_note, search_notes, list_folders.
+
+---

--- a/README.md
+++ b/README.md
@@ -1073,14 +1073,20 @@ No description available.
 
 ## MCP Servers for Obsidian
 
-*External MCP (Model Context Protocol) servers that provide AI agent access to Obsidian vaults. Unlike plugins, these run as separate processes and connect via the MCP protocol.*
+Model Context Protocol (MCP) servers that provide AI agents with access to your Obsidian vault.
+Unlike Obsidian plugins, these run as external servers and enable AI assistants to read, write, and search your notes.
+
+---
 
 ### EVC Team Relay MCP
 
 [![GitHub stars](https://img.shields.io/github/stars/entire-vc/evc-team-relay-mcp?style=flat-square)](https://github.com/entire-vc/evc-team-relay-mcp)
 [![GitHub](https://img.shields.io/badge/GitHub-entire--vc%2Fevc--team--relay--mcp-181717?logo=github)](https://github.com/entire-vc/evc-team-relay-mcp)
-[![PyPI](https://img.shields.io/badge/PyPI-evc--team--relay--mcp-blue?logo=pypi)](https://pypi.org/project/evc-team-relay-mcp/)
+[![PyPI](https://img.shields.io/pypi/v/evc-team-relay-mcp?style=flat-square)](https://pypi.org/project/evc-team-relay-mcp/)
+[![Smithery](https://smithery.ai/badge/entire-vc/evc-team-relay-mcp)](https://smithery.ai/server/entire-vc/evc-team-relay-mcp)
 
-Give AI agents read/write access to your Obsidian vault through Team Relay collaborative server. Python, MIT. 5 MCP tools: list_notes, read_note, write_note, search_notes, list_folders.
+Give AI agents (Claude, Cursor, etc.) read/write access to your Obsidian vault via MCP. Supports listing notes, reading, writing, searching, and listing folders. Designed for team collaboration with multi-user shared vault access.
+
+**Tools:** `list_notes`, `read_note`, `write_note`, `search_notes`, `list_folders`
 
 ---


### PR DESCRIPTION
## Adding MCP Servers section

This PR adds a new 'MCP Servers for Obsidian' section to the list.

MCP (Model Context Protocol) servers are an emerging category of AI tools that give AI agents direct access to Obsidian vaults. They run as external processes and connect via the MCP protocol, complementing the existing plugin ecosystem.

**Added server:** [evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp)
- Give AI agents read/write access to your Obsidian vault through Team Relay collaborative server
- Python, MIT license
- 5 MCP tools: list_notes, read_note, write_note, search_notes, list_folders
- PyPI: https://pypi.org/project/evc-team-relay-mcp/
- Works with Claude, Cline, Cursor, and other MCP-compatible AI clients

Homepage: https://entire.vc/team-relay/ai/
