### PR TITLE
Add lilbee to Knowledge Management & RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Obsidian plugin for AI-generated note refreshers
 [![GitHub](https://img.shields.io/badge/GitHub-tobocop2%2Fobsidian--lilbee-181717?logo=github)](https://github.com/tobocop2/obsidian-lilbee)
 [![Add Plugin](https://img.shields.io/badge/Obsidian-Add_Plugin-7c3aed?logo=obsidian)](https://obsidian.md/plugins?id=lilbee)
 
-A local AI search engine for your vault that runs its own models, so there is no Ollama to install. It indexes your notes, PDFs, code, and scans, crawls websites into your vault, and every answer cites the source line you click back to.
+A local AI search engine for your vault that runs its own models, so there is no Ollama to install, though you can point it at Ollama or LM Studio if you already manage models with them. It indexes your notes, PDFs, code, and scans, crawls websites into your vault, and every answer cites the source line you click back to.
 
 ***4** stars | Updated: 2026-06-14*
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Obsidian plugin for AI-generated note refreshers
 [![GitHub](https://img.shields.io/badge/GitHub-tobocop2%2Fobsidian--lilbee-181717?logo=github)](https://github.com/tobocop2/obsidian-lilbee)
 [![Add Plugin](https://img.shields.io/badge/Obsidian-Add_Plugin-7c3aed?logo=obsidian)](https://obsidian.md/plugins?id=lilbee)
 
-A local AI search engine for your vault that runs its own models, so there is no Ollama to install, though you can point it at Ollama or LM Studio if you already manage models with them. It indexes your notes, PDFs, code, and scans, crawls websites into your vault, and every answer cites the source line you click back to.
+A local AI search engine for your vault that runs its own models, so there is no Ollama to install, though you can point it at Ollama or LM Studio if you already manage models with them. It indexes your notes, PDFs, code, and scans, crawls websites into your vault, and every answer carries a citation you click to jump straight to the exact source line in Obsidian.
 
 ***4** stars | Updated: 2026-06-14*
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ Obsidian plugin for AI-generated note refreshers
 *Updated: 2024-10-18*
 
 ---
+#### lilbee
+
+[![GitHub stars](https://img.shields.io/github/stars/tobocop2/obsidian-lilbee?style=flat-square)](https://github.com/tobocop2/obsidian-lilbee)
+[![GitHub](https://img.shields.io/badge/GitHub-tobocop2%2Fobsidian--lilbee-181717?logo=github)](https://github.com/tobocop2/obsidian-lilbee)
+[![Add Plugin](https://img.shields.io/badge/Obsidian-Add_Plugin-7c3aed?logo=obsidian)](https://obsidian.md/plugins?id=lilbee)
+
+A local AI search engine for your vault that runs its own models, so there is no Ollama to install. It indexes your notes, PDFs, code, and scans, crawls websites into your vault, and every answer cites the source line you click back to.
+
+***4** stars | Updated: 2026-06-14*
+
+---
+
 ### Local LLM Integration
 
 *11 plugins | 4,001 total stars*


### PR DESCRIPTION
Adds the lilbee Obsidian plugin to **Knowledge Management & RAG**, using the list's per-plugin format (stars badge, GitHub link, Add Plugin link, description, stars and updated date).

lilbee is a local AI search engine for your vault. It runs its own local models, so there is no Ollama or LM Studio to install first, indexes your notes, PDFs, code, and scans, crawls websites into your vault, and answers with a citation you click to jump straight to the exact source line, right inside Obsidian.

**Links**
- Install (Obsidian community plugins): https://community.obsidian.md/plugins/lilbee
- Tutorial: https://obsidian.lilbee.sh/tutorial
- Project page: https://obsidian.lilbee.sh
- Source: https://github.com/tobocop2/obsidian-lilbee

![What is lilbee](https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.gif)
